### PR TITLE
add multi-step predictions for returns and VaR

### DIFF
--- a/src/univariatearchmodel.jl
+++ b/src/univariatearchmodel.jl
@@ -218,13 +218,15 @@ function predict(am::UnivariateARCHModel{T, VS, SD}, what=:volatility, horizon=1
 	if horizon > 1 && what == :VaR
 		error("Predicting VaR more than one period ahead is not implemented. Consider predicting one period ahead and scaling by `sqrt(horizon)`.")
 	end
-	for t = length(am.data) .+ (1 : horizon)
+    data = copy(am.data)
+	for t = length(data) .+ (1 : horizon)
 		if what == :return || what == :VaR
 			themean = mean(at, ht, lht, am.data, am.meanspec, am.meanspec.coefs, t)
 		end
 		update!(ht, lht, zt, at, VS, am.spec.coefs)
 		push!(zt, 0.)
 		push!(at, 0.)
+        push!(data, themean)
 	end
 	if what == :return
 		return themean

--- a/src/univariatearchmodel.jl
+++ b/src/univariatearchmodel.jl
@@ -215,16 +215,13 @@ function predict(am::UnivariateARCHModel{T, VS, SD}, what=:volatility, horizon=1
 	zt = residuals(am)
 	at = residuals(am, standardized=false)
 	themean = T(0)
-	if horizon > 1 && what == :VaR
-		error("Predicting VaR more than one period ahead is not implemented. Consider predicting one period ahead and scaling by `sqrt(horizon)`.")
-	end
-	for t = length(am.data) .+ (1 : horizon)
-		if what == :return || what == :VaR
-			themean = mean(at, ht, lht, am.data, am.meanspec, am.meanspec.coefs, t)
-		end
+	data = copy(am.data)
+	for t = length(data) .+ (1 : horizon)
+		themean = mean(at, ht, lht, data, am.meanspec, am.meanspec.coefs, t)
 		update!(ht, lht, zt, at, VS, am.spec.coefs)
 		push!(zt, 0.)
 		push!(at, 0.)
+        push!(data, themean)
 	end
 	if what == :return
 		return themean

--- a/src/univariatearchmodel.jl
+++ b/src/univariatearchmodel.jl
@@ -215,13 +215,16 @@ function predict(am::UnivariateARCHModel{T, VS, SD}, what=:volatility, horizon=1
 	zt = residuals(am)
 	at = residuals(am, standardized=false)
 	themean = T(0)
-	data = copy(am.data)
-	for t = length(data) .+ (1 : horizon)
-		themean = mean(at, ht, lht, data, am.meanspec, am.meanspec.coefs, t)
+	if horizon > 1 && what == :VaR
+		error("Predicting VaR more than one period ahead is not implemented. Consider predicting one period ahead and scaling by `sqrt(horizon)`.")
+	end
+	for t = length(am.data) .+ (1 : horizon)
+		if what == :return || what == :VaR
+			themean = mean(at, ht, lht, am.data, am.meanspec, am.meanspec.coefs, t)
+		end
 		update!(ht, lht, zt, at, VS, am.spec.coefs)
 		push!(zt, 0.)
 		push!(at, 0.)
-        push!(data, themean)
 	end
 	if what == :return
 		return themean

--- a/src/univariatearchmodel.jl
+++ b/src/univariatearchmodel.jl
@@ -205,9 +205,11 @@ end
 
 """
     predict(am::UnivariateARCHModel, what=:volatility; level=0.01, horizon=1)
-Form a 1-step ahead prediction from `am`. `what` controls which object is predicted.
+Form a `horizon`-step ahead prediction from `am`. `what` controls which object is predicted.
 The choices are `:volatility` (the default), `:variance`, `:return`, and `:VaR`. The VaR
 level can be controlled with the keyword argument `level`.
+
+For `what=:VaR`, only a `horizon = 1` horizon is currently supported.
 """
 function predict(am::UnivariateARCHModel{T, VS, SD}, what=:volatility, horizon=1; level=0.01) where {T, VS, SD, MS}
 	ht = volatilities(am).^2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,10 +177,10 @@ end
     @test islinear(am::UnivariateARCHModel) == false
     @test predict(am) ≈ 4.361606730361275
     @test predict(am, :variance) ≈ 19.023613270332767
-    @test predict(am, :return) == 0.0
     @test predict(am, :VaR) ≈ 10.146614544578197
-    @test predict.(am, :variance, 1:3) == [predict(am, :variance, h) for h in 1:3]
-    @test_throws Base.ErrorException predict.(am, :VaR, 1:3)
+    for what in [:return, :variance, :VaR]
+        @test predict.(am, what, 1:3) == [predict(am, what, h) for h in 1:3]
+    end
 end
 
 @testset "MeanSpecs" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,10 +177,10 @@ end
     @test islinear(am::UnivariateARCHModel) == false
     @test predict(am) ≈ 4.361606730361275
     @test predict(am, :variance) ≈ 19.023613270332767
+    @test predict(am, :return) == 0.0
     @test predict(am, :VaR) ≈ 10.146614544578197
-    for what in [:return, :variance, :VaR]
-        @test predict.(am, what, 1:3) == [predict(am, what, h) for h in 1:3]
-    end
+    @test predict.(am, :variance, 1:3) == [predict(am, :variance, h) for h in 1:3]
+    @test_throws Base.ErrorException predict.(am, :VaR, 1:3)
 end
 
 @testset "MeanSpecs" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,7 +179,9 @@ end
     @test predict(am, :variance) ≈ 19.023613270332767
     @test predict(am, :return) == 0.0
     @test predict(am, :VaR) ≈ 10.146614544578197
-    @test predict.(am, :variance, 1:3) == [predict(am, :variance, h) for h in 1:3]
+    for what in [:return, :variance]
+        @test predict.(am, what, 1:3) == [predict(am, what, h) for h in 1:3]
+    end
     @test_throws Base.ErrorException predict.(am, :VaR, 1:3)
 end
 


### PR DESCRIPTION
This PR adds in multi-step forecasts for `what=:return` and `what=:VaR` by using the one-period prediction for time `t` of `return` as the data for the `t+1` prediction