### PR TITLE
Several fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ARCHModels"
 uuid = "6d3278bc-c23a-5105-85e5-0d57d2bf684f"
 authors = ["Simon Broda <simon.broda@alumni.ethz.ch> and contributors."]
-version = "2.2"
+version = "2.2.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/general.jl
+++ b/src/general.jl
@@ -44,7 +44,7 @@ function vcov(am::ARCHModel)
     Ji = try
         inv(J)
     catch e
-        if e isa LinearAlgebra.SingularException
+        if e in [LinearAlgebra.SingularException, LinearAlgebra.LAPACKException(1)]
             @warn "Fisher information is singular; vcov matrix is inaccurate."
             pinv(J)
         else

--- a/src/meanspecs.jl
+++ b/src/meanspecs.jl
@@ -171,7 +171,7 @@ function constraints(::Type{<:ARMA{p, q}}, ::Type{T})  where {T<:AbstractFloat, 
     return lower, upper
 end
 
-function startingvals(::ARMA{p, q, T}, data::Vector{T})  where {p, q, T<:AbstractFloat}
+function startingvals(mod::ARMA{p, q, T}, data::Vector{T})  where {p, q, T<:AbstractFloat}
     N = length(data)
     X = Matrix{T}(undef, N-p, p+1)
     X[:, 1] .= T(1)
@@ -179,6 +179,9 @@ function startingvals(::ARMA{p, q, T}, data::Vector{T})  where {p, q, T<:Abstrac
         X[:, i+1] .= data[p-i+1:N-i]
     end
     phi = X \ data[p+1:end]
+    lower, upper = constraints(ARMA{p, q}, T)
+    phi[2:end] .= max.(phi[2:end], lower[2:p+1]*.99)
+    phi[2:end] .= min.(phi[2:end], upper[2:p+1]*.99)
     return T[phi..., zeros(T, q)...]
 end
 

--- a/src/univariatearchmodel.jl
+++ b/src/univariatearchmodel.jl
@@ -291,7 +291,7 @@ end
                          ) where {VS<:UnivariateVolatilitySpec, SD<:StandardizedDistribution,
                                   MS<:MeanSpec, T1<:AbstractFloat, T2, T3
                                   }
-    garchcoefs, distcoefs, meancoefs = splitcoefs(coefs, VS, SD, meanspec)	
+    garchcoefs, distcoefs, meancoefs = splitcoefs(coefs, VS, SD, meanspec)
 	lowergarch, uppergarch = constraints(VS, T1)
 	lowerdist, upperdist = constraints(SD, T1)
     lowermean, uppermean = constraints(MS, T1)
@@ -513,7 +513,7 @@ minimizes the [BIC](https://en.wikipedia.org/wiki/Bayesian_information_criterion
 - `algorithm=BFGS(), autodiff=:forward, kwargs...`: passed on to the optimizer.
 
 # Example
-```jldoctest
+```
 julia> selectmodel(EGARCH, BG96)
 
 EGARCH{1, 1, 2} model with Gaussian errors, T=1974.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -454,3 +454,9 @@ end
     str = sprint(io -> show(io, ccc.spec))
     @test startswith(str, "DCC{0, 0")
 end
+@testset fixes begin
+    X = [-49.78749999996362, 2951.7375000000347, 1496.437499999923, 973.8375, 2440.662500000128, 2578.062500000019, 1064.42500000032, 3378.0625000002415, -1971.5000000001048, 4373.899999999894]
+    am = fit(GARCH{2, 2}, X; meanspec = ARMA{2, 2});
+    @test length(volatilities(am)) == 10
+    @test loglikelihood(am) ≈ -86.01774
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -454,7 +454,7 @@ end
     str = sprint(io -> show(io, ccc.spec))
     @test startswith(str, "DCC{0, 0")
 end
-@testset fixes begin
+@testset "fixes" begin
     X = [-49.78749999996362, 2951.7375000000347, 1496.437499999923, 973.8375, 2440.662500000128, 2578.062500000019, 1064.42500000032, 3378.0625000002415, -1971.5000000001048, 4373.899999999894]
     am = fit(GARCH{2, 2}, X; meanspec = ARMA{2, 2});
     @test length(volatilities(am)) == 10


### PR DESCRIPTION
This fixes an issue where infeasible parameter values were generated for certain ARMA models. Also, loglik! bailed early in these cases, making it impossible to construct, e.g., residuals or volatilities.

Closes #102
