### PR TITLE
Remove initial newline from show()

### DIFF
--- a/src/DCC.jl
+++ b/src/DCC.jl
@@ -395,7 +395,7 @@ show(io::IO, am::MultivariateARCHModel) = show(io, "text/plain", am)
 function show(io::IO, ::MIME"text/plain", am::MultivariateARCHModel{T, d, MVS}) where {T, d, p, q, VS, MVS<:DCC{p, q, VS}}    
     r = p + q
     cc = coef(am)[1:r]
-    println(io, "\n", "$d-dimensional DCC{$p, $q} - $(modname(VS)) - $(modname(typeof(am.meanspec[1]))) specification, T=", size(am.data)[1], ".\n")
+    println(io, "$d-dimensional DCC{$p, $q} - $(modname(VS)) - $(modname(typeof(am.meanspec[1]))) specification, T=", size(am.data)[1], ".")
     if isfitted(am) && (:se=>true) in io
         se = stderror(am)[1:r]
         z = cc ./ se
@@ -413,7 +413,7 @@ function show(io::IO, ::MIME"text/plain", am::MultivariateARCHModel{T, d, MVS}) 
     	    show(io, "text/plain", CoefTable(cc, coefnames(MVS), [""]))
             println(io)
             if isfitted(am)
-                println(io, "\n","""Calculating standard errors is expensive. To show them, use
+                println(io, """Calculating standard errors is expensive. To show them, use
                  `show(IOContext(stdout, :se=>true), <model>)`""")
             end
         end

--- a/src/univariatearchmodel.jl
+++ b/src/univariatearchmodel.jl
@@ -594,8 +594,8 @@ function show(io::IO, ::MIME"text/plain", am::UnivariateARCHModel)
 	    zzg = ccg ./ seg
 	    zzd = ccd ./ sed
 	    zzm = ccm ./ sem
-	    println(io, "\n", modname(typeof(am.spec)), " model with ",
-	            distname(typeof(am.dist)), " errors, T=", nobs(am), ".\n")
+	    println(io, modname(typeof(am.spec)), " model with ",
+	            distname(typeof(am.dist)), " errors, T=", nobs(am), ".")
 
 	    if length(sem) > 0
 			println(io, "Mean equation parameters:")
@@ -607,7 +607,7 @@ function show(io::IO, ::MIME"text/plain", am::UnivariateARCHModel)
 			println(io)
 		end
 
-	    println(io, "\nVolatility parameters:")
+	    println(io, "Volatility parameters:")
 	    show(io, "text/plain",   CoefTable(hcat(ccg, seg, zzg, 2.0 * normccdf.(abs.(zzg))),
 					                       ["Estimate", "Std.Error", "z value", "Pr(>|z|)"],
 					                       coefnames(typeof(am.spec)), 4
@@ -615,7 +615,7 @@ function show(io::IO, ::MIME"text/plain", am::UnivariateARCHModel)
 	        )
 		println(io)
 	    if length(sed) > 0
-			println(io, "\nDistribution parameters:")
+			println(io, "Distribution parameters:")
             show(io, "text/plain", CoefTable(hcat(ccd, sed, zzd, 2.0 * normccdf.(abs.(zzd))),
 						                     ["Estimate", "Std.Error", "z value", "Pr(>|z|)"],
 						                     coefnames(typeof(am.dist)), 4
@@ -624,8 +624,9 @@ function show(io::IO, ::MIME"text/plain", am::UnivariateARCHModel)
 		end
 
    else
-	   println(io, "\n", modname(typeof(am.spec)), " model with ",
-			   distname(typeof(am.dist)), " errors, T=", nobs(am), ".\n\n")
+	   println(io, modname(typeof(am.spec)), " model with ",
+			   distname(typeof(am.dist)), " errors, T=", nobs(am), ".")
+	   println()
 	   length(am.meanspec.coefs) > 0 && show(io, "text/plain", CoefTable(am.meanspec.coefs, coefnames(am.meanspec), ["Mean equation parameters:"]))
 	   show(io, "text/plain", CoefTable(am.spec.coefs, coefnames(typeof(am.spec)), ["Volatility parameters:   "]))
 	   length(am.dist.coefs) > 0 && show(io, "text/plain", CoefTable(am.dist.coefs, coefnames(typeof(am.dist)), ["Distribution parameters: "]))


### PR DESCRIPTION
On Base.show() the print shouldn't start with a \n

For example, in the following code the last line does not display properly in vscode:

```julia
import ARCHModels
rets = rand(Float64, (100,5))
volspec = ARCHModels.CCC(Statistics.cor(rets), Float64[], [ARCHModels.GARCH{1, 1}([1., .9, .05]) for _ in 1:2])
model = ARCHModels.MultivariateARCHModel(volspec, rets)
```