### PR TITLE
Remove obsolete lgamma hack and ForwardDiff workaround

### DIFF
--- a/src/ARCHModels.jl
+++ b/src/ARCHModels.jl
@@ -14,17 +14,9 @@ using Reexport
 @reexport using StatsBase
 using StatsFuns: normcdf, normccdf, normlogpdf, norminvcdf, log2π, logtwo, RFunctions.tdistinvcdf, RFunctions.gammainvcdf
 using GLM: modelmatrix, response, LinearModel
-using SpecialFunctions: beta, gamma, digamma #, lgamma
+using SpecialFunctions: beta, gamma, digamma, loggamma
 using MuladdMacro
 using PrecompileTools
-# work around https://github.com/JuliaMath/SpecialFunctions.jl/issues/186
-# until https://github.com/JuliaDiff/ForwardDiff.jl/pull/419/ is merged
-# remove test in runtests.jl as well when this gets fixed
-using Base.Math: libm
-using ForwardDiff: Dual, value, partials
-@inline lgamma(x::Float64) = ccall((:lgamma, libm), Float64, (Float64,), x)
-@inline lgamma(x::Float32) = ccall((:lgammaf, libm), Float32, (Float32,), x)
-@inline lgamma(d::Dual{T}) where T = Dual{T}(lgamma(value(d)), digamma(value(d)) * partials(d))
 
 
 using Optim

--- a/src/univariatestandardizeddistributions.jl
+++ b/src/univariatestandardizeddistributions.jl
@@ -146,9 +146,9 @@ StdT(ν::Vector{T}) where {T} = StdT{T}(ν)
 (rand(rng::AbstractRNG, d::StdT{T})::T) where {T}  =  (ν=d.coefs[1]; rand(rng, TDist(ν))*sqrt((ν-2)/ν))
 @inline kernelinvariants(::Type{<:StdT}, coefs) = (1/ (coefs[1]-2),)
 @inline logkernel(::Type{<:StdT}, x, coefs, iv) = (-(coefs[1] + 1) / 2) * log1p(abs2(x) *iv)
-@inline logconst(::Type{<:StdT}, coefs)  = (lgamma((coefs[1] + 1) / 2)
+@inline logconst(::Type{<:StdT}, coefs)  = (loggamma((coefs[1] + 1) / 2)
                                                - log((coefs[1]-2) * pi) / 2
-                                               - lgamma(coefs[1] / 2)
+                                               - loggamma(coefs[1] / 2)
                                                )
 nparams(::Type{<:StdT}) = 1
 coefnames(::Type{<:StdT}) = ["ν"]
@@ -210,7 +210,7 @@ StdGED(v::Vector{T}) where {T} = StdGED{T}(v)
 (rand(rng::AbstractRNG, d::StdGED{T})::T) where {T} = (p = d.coefs[1]; ip=1/p;  (2*rand(rng)-1)*rand(rng, Gamma(1+ip, 1))^ip * sqrt(gamma(ip) / gamma(3*ip)) )
 
 
-@inline logconst(::Type{<:StdGED}, coefs)  = (p = coefs[1]; ip = 1/p; lgamma(3*ip)/2 - lgamma(ip)*3/2 - logtwo  - log(ip))
+@inline logconst(::Type{<:StdGED}, coefs)  = (p = coefs[1]; ip = 1/p; loggamma(3*ip)/2 - loggamma(ip)*3/2 - logtwo  - log(ip))
 @inline logkernel(::Type{<:StdGED}, x, coefs, s) = (p = coefs[1]; -abs(x*s)^p)
 @inline kernelinvariants(::Type{<:StdGED}, coefs) = (p = coefs[1]; ip = 1/p; (sqrt(gamma(3*ip) / gamma(ip)),))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,6 @@ using StableRNGs
 
 T = 10^4;
 
-@testset "lgamma" begin
-    @test ARCHModels.lgamma(1.0f0) == 0.0f0
-end
-
 @testset "TGARCH" begin
     @test ARCHModels.nparams(TGARCH{1, 2, 3}) == 7
     @test ARCHModels.presample(TGARCH{1, 2, 3}) == 3


### PR DESCRIPTION
- Remove custom lgamma definitions and Base.Math libm usage (the SpecialFunctions + ForwardDiff issues were fixed years ago).
- Import loggamma from SpecialFunctions instead.
- Replace all lgamma calls in StdT/StdGED logconst with loggamma.
- Remove the dedicated lgamma testset.

This cleans up significant technical debt while preserving identical numerical behavior (loggamma is the modern replacement for lgamma).

All tests pass.